### PR TITLE
Add TOTP 2FA and passkeys as login methods

### DIFF
--- a/docs/MFA.md
+++ b/docs/MFA.md
@@ -1,0 +1,71 @@
+/**
+ * MFA (TOTP + passkeys) for Mifos X Web App
+ *
+ * status: current
+ * audience: developers, installer-admin
+ * related: docs/getting-started/first-login.md, docs/SECURITY_REVIEW.md
+ */
+
+# Multi-factor authentication (TOTP & passkeys)
+
+The app supports three second-factor / alternate login methods:
+
+| Method | When it appears | Backend |
+| --- | --- | --- |
+| Fineract SMS / email OTP | Fineract `twofactor` is enabled for the user | Fineract `/twofactor` |
+| TOTP authenticator | User enrolled under **Profile → Security** | App MFA layer (`environment.mfa`) |
+| Passkey (WebAuthn) | User enrolled a passkey; also offered on the login form | App MFA layer |
+
+## Configuration
+
+```ts
+// environment.ts / environment.prod.ts
+mfa: {
+  demoMode: true,          // local IndexedDB vault (dev/e2e)
+  rpId: '',                // empty → window.location.hostname
+  rpName: 'Mifos X',
+  apiPath: '/mfa'          // HTTP sidecar when demoMode is false
+}
+```
+
+- **`demoMode: true`** (default in development): TOTP secrets and passkey credential IDs live in the browser vault `mifosXMfaVault`. Passwordless passkey login restores the session captured when the passkey was registered. Suitable for local demos and Playwright; **not** for production.
+- **`demoMode: false`**: the SPA calls the MFA HTTP API under `apiPath`. That service must store secrets server-side and, when Fineract platform 2FA is also required, return `{ token, validTo }` compatible with `POST /twofactor/validate`.
+
+## User flows
+
+1. **Enroll TOTP** — Sign in → Profile → Security → Set up authenticator → scan QR / enter secret → confirm with a live code.
+2. **Login with TOTP** — Password succeeds → MFA challenge → enter 6-digit code.
+3. **Enroll passkey** — Profile → Security → Register passkey (browser ceremony).
+4. **MFA with passkey** — After password, choose Passkey on the challenge screen.
+5. **Passwordless passkey** — Login form → Sign in with passkey (demo restores enrollment session; production expects `/mfa/passkey/login`).
+
+## HTTP contract (production sidecar)
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/mfa/status?username=` | Enrollment status |
+| POST | `/mfa/totp/setup` | Begin TOTP enrollment |
+| POST | `/mfa/totp/confirm` | Confirm TOTP with code |
+| DELETE | `/mfa/totp` | Disable TOTP |
+| POST | `/mfa/webauthn/register/options` | Creation options |
+| POST | `/mfa/webauthn/register` | Store new credential |
+| DELETE | `/mfa/webauthn/credentials/:id` | Remove passkey |
+| POST | `/mfa/webauthn/assert/options` | Assertion options |
+| POST | `/mfa/challenge/totp` | Validate TOTP during login |
+| POST | `/mfa/challenge/webauthn` | Validate assertion during login |
+| POST | `/mfa/passkey/login` | Passwordless; returns Fineract credentials |
+
+Challenge endpoints should return the same shape as Fineract `POST /twofactor/validate` when a platform TFA token is required:
+
+```json
+{ "token": "...", "validTo": 1710000000000, "tokenLiveTimeInSec": 3600 }
+```
+
+## Code map
+
+- `src/app/core/mfa/` — models, vault, TOTP/WebAuthn helpers, `MfaService`
+- `AuthenticationService` — gates login on MFA after first factor; `validateTotpChallenge` / `validatePasskeyChallenge` / `loginWithPasskey`
+- Login `TwoFactorAuthenticationComponent` — method chooser (TOTP / passkey / SMS-email)
+- `SecuritySettingsComponent` on Profile — enrollment UI
+
+Apache Fineract does not ship TOTP or WebAuthn; keep the Fineract OTP path for SMS/email and use the MFA layer (or a Fineract plugin) for authenticator apps and passkeys.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -6,4 +6,6 @@ Use `npm run docs` for easier navigation.
 
 ## Available documentation
 
+- [Multi-factor authentication (TOTP & passkeys)](MFA.md)
+
 [[index]]

--- a/e2e/fixtures/api-mocks.ts
+++ b/e2e/fixtures/api-mocks.ts
@@ -59,6 +59,22 @@ export async function mockFineractApi(page: Page): Promise<void> {
       body: JSON.stringify([]),
     });
   });
+
+  await page.route('**/twofactor**', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ tokenLiveTimeInSec: 300 }),
+    });
+  });
 }
 
 /**
@@ -68,5 +84,57 @@ export async function clearClientStorage(page: Page): Promise<void> {
   await page.addInitScript(() => {
     localStorage.clear();
     sessionStorage.clear();
+    try {
+      indexedDB.deleteDatabase('mifosXMfaVault');
+    } catch {
+      // Ignore — not all browsers expose IndexedDB during init.
+    }
   });
+}
+
+/**
+ * Seeds the demo MFA IndexedDB vault with an enabled TOTP secret.
+ */
+export async function seedDemoTotp(
+  page: Page,
+  options: { username: string; secret: string; tenantId?: string }
+): Promise<void> {
+  const tenantId = options.tenantId ?? 'default';
+  await page.evaluate(
+    async ({ username, secret, tenantId: tenant }) => {
+      await new Promise<void>((resolve) => {
+        const del = indexedDB.deleteDatabase('mifosXMfaVault');
+        del.onsuccess = () => resolve();
+        del.onerror = () => resolve();
+        del.onblocked = () => resolve();
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        const open = indexedDB.open('mifosXMfaVault', 1);
+        open.onupgradeneeded = () => {
+          const db = open.result;
+          if (!db.objectStoreNames.contains('accounts')) {
+            db.createObjectStore('accounts', { keyPath: 'key' });
+          }
+        };
+        open.onsuccess = () => {
+          const db = open.result;
+          const tx = db.transaction('accounts', 'readwrite');
+          tx.objectStore('accounts').put({
+            key: `${tenant}::${username.toLowerCase()}`,
+            username,
+            tenantId: tenant,
+            totpSecret: secret,
+            totpEnabled: true,
+            passkeys: [],
+            passkeyPublicKeys: {}
+          });
+          tx.oncomplete = () => resolve();
+          tx.onerror = () => reject(tx.error ?? new Error('Failed to seed MFA vault'));
+        };
+        open.onerror = () => reject(open.error ?? new Error('Failed to open MFA vault'));
+      });
+    },
+    { username: options.username, secret: options.secret, tenantId }
+  );
 }

--- a/e2e/fixtures/api-mocks.ts
+++ b/e2e/fixtures/api-mocks.ts
@@ -60,7 +60,7 @@ export async function mockFineractApi(page: Page): Promise<void> {
     });
   });
 
-  await page.route('**/twofactor**', async (route) => {
+  await page.route(/\/twofactor(\?|$)/, async (route) => {
     if (route.request().method() === 'GET') {
       await route.fulfill({
         status: 200,
@@ -84,11 +84,20 @@ export async function clearClientStorage(page: Page): Promise<void> {
   await page.addInitScript(() => {
     localStorage.clear();
     sessionStorage.clear();
-    try {
-      indexedDB.deleteDatabase('mifosXMfaVault');
-    } catch {
-      // Ignore — not all browsers expose IndexedDB during init.
-    }
+  });
+}
+
+/**
+ * Clears the demo MFA IndexedDB vault (call after navigation so IndexedDB is available).
+ */
+export async function clearDemoMfaVault(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    await new Promise<void>((resolve) => {
+      const del = indexedDB.deleteDatabase('mifosXMfaVault');
+      del.onsuccess = () => resolve();
+      del.onerror = () => resolve();
+      del.onblocked = () => resolve();
+    });
   });
 }
 
@@ -100,15 +109,9 @@ export async function seedDemoTotp(
   options: { username: string; secret: string; tenantId?: string }
 ): Promise<void> {
   const tenantId = options.tenantId ?? 'default';
+  await clearDemoMfaVault(page);
   await page.evaluate(
     async ({ username, secret, tenantId: tenant }) => {
-      await new Promise<void>((resolve) => {
-        const del = indexedDB.deleteDatabase('mifosXMfaVault');
-        del.onsuccess = () => resolve();
-        del.onerror = () => resolve();
-        del.onblocked = () => resolve();
-      });
-
       await new Promise<void>((resolve, reject) => {
         const open = indexedDB.open('mifosXMfaVault', 1);
         open.onupgradeneeded = () => {

--- a/e2e/mfa.spec.ts
+++ b/e2e/mfa.spec.ts
@@ -28,10 +28,11 @@ test.describe('MFA (TOTP)', () => {
 
     await submitLogin(page, 'mifos', 'password');
 
-    await expect(page.getByText('Multi-Factor Authentication')).toBeVisible();
-    await expect(page.getByLabel('Authenticator code')).toBeVisible();
+    await expect(page.locator('mifosx-two-factor-authentication')).toBeVisible();
+    const codeInput = page.locator('mifosx-two-factor-authentication input[formcontrolname="code"]');
+    await expect(codeInput).toBeVisible();
 
-    await page.getByLabel('Authenticator code').fill(currentTotpCode(DEMO_SECRET));
+    await codeInput.fill(currentTotpCode(DEMO_SECRET));
     await page.getByRole('button', { name: 'Verify' }).click();
 
     await expect(page).toHaveURL(/\/home/);
@@ -43,12 +44,15 @@ test.describe('MFA (TOTP)', () => {
     await seedDemoTotp(page, { username: 'mifos', secret: DEMO_SECRET });
 
     await submitLogin(page, 'mifos', 'password');
-    await expect(page.getByLabel('Authenticator code')).toBeVisible();
 
-    await page.getByLabel('Authenticator code').fill('000000');
+    await expect(page.locator('mifosx-two-factor-authentication')).toBeVisible();
+    const codeInput = page.locator('mifosx-two-factor-authentication input[formcontrolname="code"]');
+    await expect(codeInput).toBeVisible();
+
+    await codeInput.fill('000000');
     await page.getByRole('button', { name: 'Verify' }).click();
 
-    await expect(page.getByText(/Invalid authenticator code/i)).toBeVisible();
+    await expect(page.locator('mifosx-two-factor-authentication .mfa-error')).toBeVisible();
     await expect(page).toHaveURL(/\/login/);
   });
 });

--- a/e2e/mfa.spec.ts
+++ b/e2e/mfa.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { TOTP, Secret } from 'otpauth';
+
+import { clearClientStorage, mockFineractApi, seedDemoTotp } from './fixtures/api-mocks';
+import { submitLogin } from './fixtures/login-helpers';
+
+const DEMO_SECRET = 'JBSWY3DPEHPK3PXP';
+
+function currentTotpCode(secretBase32: string): string {
+  const totp = new TOTP({
+    algorithm: 'SHA1',
+    digits: 6,
+    period: 30,
+    secret: Secret.fromBase32(secretBase32)
+  });
+  return totp.generate();
+}
+
+test.describe('MFA (TOTP)', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearClientStorage(page);
+    await mockFineractApi(page);
+  });
+
+  test('should challenge for TOTP after password when authenticator is enrolled', async ({ page }) => {
+    await page.goto('/login');
+    await seedDemoTotp(page, { username: 'mifos', secret: DEMO_SECRET });
+
+    await submitLogin(page, 'mifos', 'password');
+
+    await expect(page.getByText('Multi-Factor Authentication')).toBeVisible();
+    await expect(page.getByLabel('Authenticator code')).toBeVisible();
+
+    await page.getByLabel('Authenticator code').fill(currentTotpCode(DEMO_SECRET));
+    await page.getByRole('button', { name: 'Verify' }).click();
+
+    await expect(page).toHaveURL(/\/home/);
+    await expect(page.locator('mifosx-shell')).toBeVisible();
+  });
+
+  test('should reject an invalid TOTP code', async ({ page }) => {
+    await page.goto('/login');
+    await seedDemoTotp(page, { username: 'mifos', secret: DEMO_SECRET });
+
+    await submitLogin(page, 'mifos', 'password');
+    await expect(page.getByLabel('Authenticator code')).toBeVisible();
+
+    await page.getByLabel('Authenticator code').fill('000000');
+    await page.getByRole('button', { name: 'Verify' }).click();
+
+    await expect(page.getByText(/Invalid authenticator code/i)).toBeVisible();
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
         "chart.js": "^4.5.1",
         "ckeditor5": "^47.7.2",
         "lodash": "^4.17.21",
+        "otpauth": "^9.5.1",
+        "qrcode": "^1.5.4",
         "rxjs": "^7.8.2",
         "tslib": "^2.8.1",
         "zone.js": "^0.15.0"
@@ -44,6 +46,7 @@
         "@playwright/test": "^1.61.1",
         "@types/lodash": "^4.17.16",
         "@types/node": "^22.15.3",
+        "@types/qrcode": "^1.5.6",
         "@vitest/coverage-v8": "^4.1.10",
         "angular-eslint": "22.0.0",
         "eslint": "^10.3.0",
@@ -4526,6 +4529,18 @@
         "rxjs": ">=7"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5833,6 +5848,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/sarif": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
@@ -6472,7 +6497,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -7404,7 +7428,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -7417,7 +7440,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-parse": {
@@ -8598,6 +8620,12 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -8752,7 +8780,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -10927,21 +10954,6 @@
         }
       }
     },
-    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -11703,21 +11715,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/lru-cache": {
@@ -14552,6 +14549,18 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/otpauth": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.5.1.tgz",
+      "integrity": "sha512-fJmDAHc8wImfqqqOXIlBvT1dEKrZK0Cmb2VEgScpNTolCz0PHh6ExUZGv4sLtOsWNaHCQlD+rRqaPgnoxFoZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/hectorm/otpauth?sponsor=1"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -14595,6 +14604,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pacote": {
@@ -14770,7 +14788,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14956,6 +14973,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -15343,6 +15369,180 @@
         "node": ">=0.9"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
@@ -15634,7 +15834,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15649,6 +15848,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
@@ -16050,6 +16255,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -16608,7 +16819,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -16623,7 +16833,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16633,7 +16842,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16643,7 +16851,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -18620,21 +18827,6 @@
         }
       }
     },
-    "node_modules/whatwg-url/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -18650,6 +18842,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "chart.js": "^4.5.1",
     "ckeditor5": "^47.7.2",
     "lodash": "^4.17.21",
+    "otpauth": "^9.5.1",
+    "qrcode": "^1.5.4",
     "rxjs": "^7.8.2",
     "tslib": "^2.8.1",
     "zone.js": "^0.15.0"
@@ -67,6 +69,7 @@
     "@playwright/test": "^1.61.1",
     "@types/lodash": "^4.17.16",
     "@types/node": "^22.15.3",
+    "@types/qrcode": "^1.5.6",
     "@vitest/coverage-v8": "^4.1.10",
     "angular-eslint": "22.0.0",
     "eslint": "^10.3.0",

--- a/src/app/core/authentication/authentication.service.ts
+++ b/src/app/core/authentication/authentication.service.ts
@@ -9,7 +9,7 @@ import { map, switchMap } from 'rxjs/operators';
 /** Custom Services */
 import { AlertService } from '../alert/alert.service';
 import { MfaService } from '../mfa/mfa.service';
-import { MfaTokenResponse } from '../mfa/mfa.models';
+import { MfaStatus, MfaTokenResponse } from '../mfa/mfa.models';
 
 /** Custom Interceptors */
 import { AuthenticationInterceptor } from './authentication.interceptor';
@@ -41,6 +41,8 @@ export class AuthenticationService {
   /** User credentials. */
 
   private credentials?: Credentials;
+  /** Cached MFA status for the pending challenge (avoids a second vault round-trip). */
+  private pendingMfaStatus: MfaStatus | null = null;
   /** Key to store credentials in storage. */
   private credentialsStorageKey = 'mifosXCredentials';
   /** Key to store oauth token details in storage. */
@@ -207,19 +209,21 @@ export class AuthenticationService {
       return of(credentials);
     }
 
-    return this.mfaService.requiresChallenge(credentials.username).pipe(
-      switchMap((required) => {
-        if (required) {
-          this.credentials = credentials;
-          this.alertService.alert({
-            type: 'Two Factor Authentication Required',
-            message: 'Multi-factor authentication required'
-          });
+    return this.mfaService.getStatus(credentials.username).pipe(
+      switchMap((status) => {
+        if (!status.methods.length) {
+          this.setCredentials(credentials);
+          this.alertService.alert({ type: 'Authentication Success', message: `${credentials.username} successfully logged in!` });
+          delete (this as any).credentials;
+          this.pendingMfaStatus = null;
           return of(credentials);
         }
-        this.setCredentials(credentials);
-        this.alertService.alert({ type: 'Authentication Success', message: `${credentials.username} successfully logged in!` });
-        delete (this as any).credentials;
+        this.credentials = credentials;
+        this.pendingMfaStatus = status;
+        this.alertService.alert({
+          type: 'Two Factor Authentication Required',
+          message: 'Multi-factor authentication required'
+        });
         return of(credentials);
       })
     );
@@ -275,6 +279,13 @@ export class AuthenticationService {
    */
   getPendingCredentials(): Credentials | null {
     return this.credentials ?? null;
+  }
+
+  /**
+   * MFA enrollment status captured when the challenge was opened.
+   */
+  getPendingMfaStatus(): MfaStatus | null {
+    return this.pendingMfaStatus;
   }
 
   /**
@@ -340,6 +351,7 @@ export class AuthenticationService {
   completeMfaChallenge(tokenResponse?: MfaTokenResponse | null): void {
     if (this.credentials?.isTwoFactorAuthenticationRequired && tokenResponse) {
       this.onOTPValidateSuccess(tokenResponse);
+      this.pendingMfaStatus = null;
       return;
     }
     if (this.credentials?.shouldRenewPassword) {
@@ -349,6 +361,7 @@ export class AuthenticationService {
     this.setCredentials(this.credentials);
     this.alertService.alert({ type: 'Authentication Success', message: `${this.credentials?.username} successfully logged in!` });
     delete (this as any).credentials;
+    this.pendingMfaStatus = null;
   }
 
   /**

--- a/src/app/core/authentication/authentication.service.ts
+++ b/src/app/core/authentication/authentication.service.ts
@@ -4,10 +4,12 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 
 /** rxjs Imports */
 import { Observable, of } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 
 /** Custom Services */
 import { AlertService } from '../alert/alert.service';
+import { MfaService } from '../mfa/mfa.service';
+import { MfaTokenResponse } from '../mfa/mfa.models';
 
 /** Custom Interceptors */
 import { AuthenticationInterceptor } from './authentication.interceptor';
@@ -52,10 +54,12 @@ export class AuthenticationService {
    * @param {HttpClient} http Http Client to send requests.
    * @param {AlertService} alertService Alert Service.
    * @param {AuthenticationInterceptor} authenticationInterceptor Authentication Interceptor.
+   * @param {MfaService} mfaService App-level MFA (TOTP / passkeys).
    */
   constructor(private http: HttpClient,
               private alertService: AlertService,
-              private authenticationInterceptor: AuthenticationInterceptor) {
+              private authenticationInterceptor: AuthenticationInterceptor,
+              private mfaService: MfaService) {
     this.rememberMe = false;
     this.storage = sessionStorage;
     const savedCredentials = JSON.parse(
@@ -103,12 +107,30 @@ export class AuthenticationService {
     } else {
       return this.http.post('/authentication', { username: loginContext.username, password: loginContext.password })
         .pipe(
-          map((credentials: any) => {
-            this.onLoginSuccess(credentials);
-            return true;
-          })
+          switchMap((credentials: any) => this.onLoginSuccess$(credentials)),
+          map(() => true)
         );
     }
+  }
+
+  /**
+   * Passwordless passkey login (WebAuthn).
+   */
+  loginWithPasskey(): Observable<boolean> {
+    this.alertService.alert({ type: 'Authentication Start', message: 'Waiting for passkey...' });
+    this.rememberMe = false;
+    this.storage = sessionStorage;
+    return this.mfaService.loginWithPasskey().pipe(
+      switchMap((result) => {
+        if (result.twoFactorToken) {
+          this.credentials = result.credentials;
+          this.applyFirstFactorAuthorization(result.credentials);
+          this.onOTPValidateSuccess(result.twoFactorToken);
+          return of(true);
+        }
+        return this.onLoginSuccess$(result.credentials).pipe(map(() => true));
+      })
+    );
   }
 
   /**
@@ -122,7 +144,7 @@ export class AuthenticationService {
     this.refreshTokenOnExpiry(tokenResponse.expires_in);
     this.http.get('/userdetails', { params: httpParams })
       .subscribe((credentials: any) => {
-        this.onLoginSuccess(credentials);
+        this.onLoginSuccess$(credentials).subscribe();
         if (!credentials.shouldRenewPassword) {
           this.storage.setItem(this.oAuthTokenDetailsStorageKey, JSON.stringify(tokenResponse));
         }
@@ -159,35 +181,48 @@ export class AuthenticationService {
       });
   }
 
-  /**
-   * Sets the authorization token followed by one of the following:
-   *
-   * Sends an alert if two factor authentication is required.
-   *
-   * Sends an alert if password has expired and requires a reset.
-   *
-   * Sends an alert on successful login.
-   * @param {Credentials} credentials Authenticated user credentials.
-   */
-  private onLoginSuccess(credentials: Credentials) {
+  private applyFirstFactorAuthorization(credentials: Credentials): void {
     if (environment.oauth.enabled) {
       this.authenticationInterceptor.setAuthorizationToken(credentials.accessToken!);
     } else {
       this.authenticationInterceptor.setAuthorizationToken(credentials.base64EncodedAuthenticationKey ?? '');
     }
+  }
+
+  /**
+   * First-factor success path with optional app-level MFA challenge.
+   */
+  private onLoginSuccess$(credentials: Credentials): Observable<Credentials> {
+    this.applyFirstFactorAuthorization(credentials);
+
     if (credentials.isTwoFactorAuthenticationRequired) {
       this.credentials = credentials;
       this.alertService.alert({ type: 'Two Factor Authentication Required', message: 'Two Factor Authentication Required' });
-    } else {
-      if (credentials.shouldRenewPassword) {
-        this.credentials = credentials;
-        this.alertService.alert({ type: 'Password Expired', message: 'Your password has expired, please reset your password!' });
-      } else {
+      return of(credentials);
+    }
+
+    if (credentials.shouldRenewPassword) {
+      this.credentials = credentials;
+      this.alertService.alert({ type: 'Password Expired', message: 'Your password has expired, please reset your password!' });
+      return of(credentials);
+    }
+
+    return this.mfaService.requiresChallenge(credentials.username).pipe(
+      switchMap((required) => {
+        if (required) {
+          this.credentials = credentials;
+          this.alertService.alert({
+            type: 'Two Factor Authentication Required',
+            message: 'Multi-factor authentication required'
+          });
+          return of(credentials);
+        }
         this.setCredentials(credentials);
         this.alertService.alert({ type: 'Authentication Success', message: `${credentials.username} successfully logged in!` });
         delete (this as any).credentials;
-      }
-    }
+        return of(credentials);
+      })
+    );
   }
 
   /**
@@ -233,6 +268,13 @@ export class AuthenticationService {
    */
   getCredentials(): Credentials | null {
     return JSON.parse(this.storage.getItem(this.credentialsStorageKey) ?? 'null');
+  }
+
+  /**
+   * Pending first-factor credentials waiting on MFA (not yet persisted).
+   */
+  getPendingCredentials(): Credentials | null {
+    return this.credentials ?? null;
   }
 
   /**
@@ -289,6 +331,56 @@ export class AuthenticationService {
           this.onOTPValidateSuccess(response);
         })
       );
+  }
+
+  /**
+   * Completes MFA after a TOTP or passkey challenge.
+   * Issues a Fineract TFA token only when the first-factor response required one.
+   */
+  completeMfaChallenge(tokenResponse?: MfaTokenResponse | null): void {
+    if (this.credentials?.isTwoFactorAuthenticationRequired && tokenResponse) {
+      this.onOTPValidateSuccess(tokenResponse);
+      return;
+    }
+    if (this.credentials?.shouldRenewPassword) {
+      this.alertService.alert({ type: 'Password Expired', message: 'Your password has expired, please reset your password!' });
+      return;
+    }
+    this.setCredentials(this.credentials);
+    this.alertService.alert({ type: 'Authentication Success', message: `${this.credentials?.username} successfully logged in!` });
+    delete (this as any).credentials;
+  }
+
+  /**
+   * Validates a TOTP code for the pending login challenge.
+   */
+  validateTotpChallenge(code: string): Observable<void> {
+    const pending = this.credentials;
+    if (!pending) {
+      throw new Error('No pending authentication challenge.');
+    }
+    const issuePlatformToken = !!pending.isTwoFactorAuthenticationRequired;
+    return this.mfaService.validateTotpChallenge(pending.username, code, issuePlatformToken).pipe(
+      map((token) => {
+        this.completeMfaChallenge(token);
+      })
+    );
+  }
+
+  /**
+   * Validates a passkey assertion for the pending login challenge.
+   */
+  validatePasskeyChallenge(): Observable<void> {
+    const pending = this.credentials;
+    if (!pending) {
+      throw new Error('No pending authentication challenge.');
+    }
+    const issuePlatformToken = !!pending.isTwoFactorAuthenticationRequired;
+    return this.mfaService.validatePasskeyChallenge(pending.username, issuePlatformToken).pipe(
+      map((token) => {
+        this.completeMfaChallenge(token);
+      })
+    );
   }
 
   /**

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -5,6 +5,7 @@ import { RouteReuseStrategy, RouterModule } from '@angular/router';
 
 /** Custom Services */
 import { AuthenticationService } from './authentication/authentication.service';
+import { MfaService } from './mfa/mfa.service';
 import { HttpService } from './http/http.service';
 import { HttpCacheService } from './http/http-cache.service';
 import { ProgressBarService } from './progress-bar/progress-bar.service';
@@ -56,6 +57,7 @@ import { ContentComponent } from './shell/content/content.component';
     ],
     providers: [
         AuthenticationService,
+        MfaService,
         AuthenticationGuard,
         AuthenticationInterceptor,
         {

--- a/src/app/core/mfa/mfa-vault.ts
+++ b/src/app/core/mfa/mfa-vault.ts
@@ -1,0 +1,208 @@
+/**
+ * Browser-local MFA vault used by demoMode for TOTP secrets, passkey
+ * credentials, and passwordless session handoff. Production builds with
+ * demoMode=false never read this vault — secrets live on the MFA server.
+ */
+
+import { Credentials } from '../authentication/credentials.model';
+import { MfaPasskeyCredential, MfaStatus } from './mfa.models';
+
+const DB_NAME = 'mifosXMfaVault';
+const DB_VERSION = 1;
+const STORE = 'accounts';
+
+export interface MfaVaultAccount {
+  username: string;
+  tenantId: string;
+  totpSecret?: string;
+  totpEnabled: boolean;
+  passkeys: MfaPasskeyCredential[];
+  /** Raw credential publicKey buffers keyed by credentialId (demo only). */
+  passkeyPublicKeys: Record<string, ArrayBuffer>;
+  /**
+   * Credentials captured when a passkey was enrolled (demo passwordless only).
+   * Not used when MFA is backed by a real server.
+   */
+  sessionHandoff?: {
+    credentials: Credentials;
+    savedAt: string;
+  };
+}
+
+function accountKey(username: string, tenantId: string): string {
+  return `${tenantId || 'default'}::${username.toLowerCase()}`;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('IndexedDB is not available in this environment.'));
+      return;
+    }
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: 'key' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error('Failed to open MFA vault'));
+  });
+}
+
+interface StoredRow extends MfaVaultAccount {
+  key: string;
+}
+
+async function getRow(username: string, tenantId: string): Promise<StoredRow | undefined> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const req = tx.objectStore(STORE).get(accountKey(username, tenantId));
+    req.onsuccess = () => resolve(req.result as StoredRow | undefined);
+    req.onerror = () => reject(req.error ?? new Error('MFA vault read failed'));
+  });
+}
+
+async function putRow(row: StoredRow): Promise<void> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).put(row);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error('MFA vault write failed'));
+  });
+}
+
+function emptyAccount(username: string, tenantId: string): StoredRow {
+  return {
+    key: accountKey(username, tenantId),
+    username,
+    tenantId,
+    totpEnabled: false,
+    passkeys: [],
+    passkeyPublicKeys: {}
+  };
+}
+
+export async function vaultGetStatus(username: string, tenantId: string): Promise<MfaStatus> {
+  const row = await getRow(username, tenantId);
+  return {
+    totpEnabled: !!row?.totpEnabled,
+    passkeys: row?.passkeys ?? [],
+    methods: [
+      ...(row?.totpEnabled ? (['totp'] as const) : []),
+      ...((row?.passkeys.length ?? 0) > 0 ? (['passkey'] as const) : [])
+    ]
+  };
+}
+
+export async function vaultGetAccount(username: string, tenantId: string): Promise<MfaVaultAccount> {
+  return (await getRow(username, tenantId)) ?? emptyAccount(username, tenantId);
+}
+
+export async function vaultSaveTotpSecret(
+  username: string,
+  tenantId: string,
+  secret: string
+): Promise<void> {
+  const row = (await getRow(username, tenantId)) ?? emptyAccount(username, tenantId);
+  row.totpSecret = secret;
+  row.totpEnabled = false;
+  await putRow(row);
+}
+
+export async function vaultConfirmTotp(username: string, tenantId: string): Promise<void> {
+  const row = await getRow(username, tenantId);
+  if (!row?.totpSecret) {
+    throw new Error('No pending TOTP enrollment for this account.');
+  }
+  row.totpEnabled = true;
+  await putRow(row);
+}
+
+export async function vaultDisableTotp(username: string, tenantId: string): Promise<void> {
+  const row = (await getRow(username, tenantId)) ?? emptyAccount(username, tenantId);
+  delete row.totpSecret;
+  row.totpEnabled = false;
+  await putRow(row);
+}
+
+export async function vaultAddPasskey(
+  username: string,
+  tenantId: string,
+  credential: MfaPasskeyCredential,
+  publicKey: ArrayBuffer,
+  sessionHandoff?: Credentials
+): Promise<void> {
+  const row = (await getRow(username, tenantId)) ?? emptyAccount(username, tenantId);
+  row.passkeys = [...row.passkeys.filter((p) => p.id !== credential.id), credential];
+  row.passkeyPublicKeys = { ...row.passkeyPublicKeys, [credential.id]: publicKey };
+  if (sessionHandoff) {
+    row.sessionHandoff = {
+      credentials: sessionHandoff,
+      savedAt: new Date().toISOString()
+    };
+  }
+  await putRow(row);
+}
+
+export async function vaultRemovePasskey(
+  username: string,
+  tenantId: string,
+  credentialId: string
+): Promise<void> {
+  const row = (await getRow(username, tenantId)) ?? emptyAccount(username, tenantId);
+  row.passkeys = row.passkeys.filter((p) => p.id !== credentialId);
+  const next = { ...row.passkeyPublicKeys };
+  delete next[credentialId];
+  row.passkeyPublicKeys = next;
+  if (row.passkeys.length === 0) {
+    delete row.sessionHandoff;
+  }
+  await putRow(row);
+}
+
+export async function vaultTouchPasskey(
+  username: string,
+  tenantId: string,
+  credentialId: string
+): Promise<void> {
+  const row = await getRow(username, tenantId);
+  if (!row) {
+    return;
+  }
+  row.passkeys = row.passkeys.map((p) =>
+    p.id === credentialId ? { ...p, lastUsedAt: new Date().toISOString() } : p
+  );
+  await putRow(row);
+}
+
+export async function vaultFindByCredentialId(
+  credentialId: string
+): Promise<StoredRow | undefined> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const req = tx.objectStore(STORE).getAll();
+    req.onsuccess = () => {
+      const rows = (req.result as StoredRow[]) ?? [];
+      resolve(rows.find((r) => r.passkeys.some((p) => p.id === credentialId)));
+    };
+    req.onerror = () => reject(req.error ?? new Error('MFA vault scan failed'));
+  });
+}
+
+export async function vaultUpdateSessionHandoff(
+  username: string,
+  tenantId: string,
+  credentials: Credentials
+): Promise<void> {
+  const row = (await getRow(username, tenantId)) ?? emptyAccount(username, tenantId);
+  row.sessionHandoff = {
+    credentials,
+    savedAt: new Date().toISOString()
+  };
+  await putRow(row);
+}

--- a/src/app/core/mfa/mfa.models.ts
+++ b/src/app/core/mfa/mfa.models.ts
@@ -1,0 +1,48 @@
+/**
+ * Multi-factor authentication models (TOTP + passkeys + legacy SMS/email OTP).
+ */
+
+export type MfaMethodType = 'sms' | 'email' | 'totp' | 'passkey';
+
+export interface MfaPasskeyCredential {
+  id: string;
+  name: string;
+  createdAt: string;
+  lastUsedAt?: string;
+}
+
+export interface MfaStatus {
+  totpEnabled: boolean;
+  passkeys: MfaPasskeyCredential[];
+  /** Enabled app-level MFA method keys. */
+  methods: Array<'totp' | 'passkey'>;
+}
+
+export interface TotpSetupResponse {
+  secret: string;
+  otpauthUri: string;
+  /** Base64 PNG data URL when available */
+  qrDataUrl?: string;
+}
+
+export interface MfaTokenResponse {
+  token: string;
+  validTo: number;
+  tokenLiveTimeInSec?: number;
+}
+
+export interface PasskeyLoginResult {
+  credentials: import('../authentication/credentials.model').Credentials;
+  twoFactorToken?: MfaTokenResponse;
+}
+
+export interface MfaConfig {
+  /** When true, TOTP secrets and passkeys are stored in a browser vault (local/demo). */
+  demoMode: boolean;
+  /** WebAuthn relying party ID (hostname). Empty uses `window.location.hostname`. */
+  rpId: string;
+  /** Relying party display name. */
+  rpName: string;
+  /** Optional HTTP base path for an MFA sidecar (used when demoMode is false). */
+  apiPath: string;
+}

--- a/src/app/core/mfa/mfa.service.ts
+++ b/src/app/core/mfa/mfa.service.ts
@@ -1,0 +1,327 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { from, Observable, of } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import QRCode from 'qrcode';
+
+import { environment } from '../../../environments/environment';
+import { Credentials } from '../authentication/credentials.model';
+import {
+  MfaPasskeyCredential,
+  MfaStatus,
+  MfaTokenResponse,
+  PasskeyLoginResult,
+  TotpSetupResponse
+} from './mfa.models';
+import {
+  vaultAddPasskey,
+  vaultConfirmTotp,
+  vaultDisableTotp,
+  vaultFindByCredentialId,
+  vaultGetAccount,
+  vaultGetStatus,
+  vaultRemovePasskey,
+  vaultSaveTotpSecret,
+  vaultTouchPasskey,
+  vaultUpdateSessionHandoff
+} from './mfa-vault';
+import { createTotpSetup, verifyTotpCode } from './totp.util';
+import {
+  assertPasskey,
+  createPasskey,
+  isWebAuthnAvailable,
+  toBase64Url
+} from './webauthn.util';
+
+function tenantId(): string {
+  return environment.fineractPlatformTenantId || 'default';
+}
+
+function mfaConfig() {
+  return environment.mfa;
+}
+
+function resolveRpId(): string {
+  const configured = mfaConfig().rpId;
+  if (configured) {
+    return configured;
+  }
+  return typeof window !== 'undefined' ? window.location.hostname : 'localhost';
+}
+
+function demoToken(validSeconds = 3600): MfaTokenResponse {
+  const validTo = Date.now() + validSeconds * 1000;
+  return {
+    token: `demo-mfa-${toBase64Url(crypto.getRandomValues(new Uint8Array(16)).buffer)}`,
+    validTo,
+    tokenLiveTimeInSec: validSeconds
+  };
+}
+
+/**
+ * Application MFA (TOTP authenticator apps + WebAuthn passkeys).
+ *
+ * When `environment.mfa.demoMode` is true, enrollment and verification run
+ * entirely in the browser vault. When false, requests go to the MFA HTTP
+ * sidecar under `environment.mfa.apiPath`.
+ */
+@Injectable()
+export class MfaService {
+
+  constructor(private http: HttpClient) {}
+
+  isDemoMode(): boolean {
+    return !!mfaConfig().demoMode;
+  }
+
+  webAuthnAvailable(): boolean {
+    return isWebAuthnAvailable();
+  }
+
+  getStatus(username: string): Observable<MfaStatus> {
+    if (this.isDemoMode()) {
+      return from(vaultGetStatus(username, tenantId()));
+    }
+    return this.http.get<MfaStatus>(`${mfaConfig().apiPath}/status`, {
+      params: { username }
+    });
+  }
+
+  requiresChallenge(username: string): Observable<boolean> {
+    return this.getStatus(username).pipe(
+      map((status) => status.methods.length > 0),
+      catchError(() => of(false))
+    );
+  }
+
+  beginTotpSetup(username: string): Observable<TotpSetupResponse> {
+    if (this.isDemoMode()) {
+      return from(this.beginTotpSetupDemo(username));
+    }
+    return this.http.post<TotpSetupResponse>(`${mfaConfig().apiPath}/totp/setup`, { username });
+  }
+
+  confirmTotpSetup(username: string, code: string): Observable<void> {
+    if (this.isDemoMode()) {
+      return from(this.confirmTotpSetupDemo(username, code));
+    }
+    return this.http.post<void>(`${mfaConfig().apiPath}/totp/confirm`, { username, code });
+  }
+
+  disableTotp(username: string): Observable<void> {
+    if (this.isDemoMode()) {
+      return from(vaultDisableTotp(username, tenantId()));
+    }
+    return this.http.request<void>('DELETE', `${mfaConfig().apiPath}/totp`, { body: { username } });
+  }
+
+  registerPasskey(
+    username: string,
+    displayName: string,
+    sessionCredentials?: Credentials
+  ): Observable<MfaPasskeyCredential> {
+    if (this.isDemoMode()) {
+      return from(this.registerPasskeyDemo(username, displayName, sessionCredentials));
+    }
+    return this.http.post<any>(`${mfaConfig().apiPath}/webauthn/register/options`, { username }).pipe(
+      switchMap((options) =>
+        from((async () => {
+          const credential = await navigator.credentials.create({ publicKey: options.publicKey });
+          if (!credential || credential.type !== 'public-key') {
+            throw new Error('Passkey registration was cancelled or failed.');
+          }
+          return credential;
+        })())
+      ),
+      switchMap((credential) =>
+        this.http.post<MfaPasskeyCredential>(`${mfaConfig().apiPath}/webauthn/register`, {
+          username,
+          name: displayName,
+          credential
+        })
+      )
+    );
+  }
+
+  removePasskey(username: string, credentialId: string): Observable<void> {
+    if (this.isDemoMode()) {
+      return from(vaultRemovePasskey(username, tenantId(), credentialId));
+    }
+    return this.http.delete<void>(`${mfaConfig().apiPath}/webauthn/credentials/${encodeURIComponent(credentialId)}`, {
+      body: { username }
+    });
+  }
+
+  validateTotpChallenge(username: string, code: string, issuePlatformToken: boolean): Observable<MfaTokenResponse | null> {
+    if (this.isDemoMode()) {
+      return from(this.validateTotpDemo(username, code, issuePlatformToken));
+    }
+    return this.http.post<MfaTokenResponse>(`${mfaConfig().apiPath}/challenge/totp`, {
+      username,
+      code
+    });
+  }
+
+  validatePasskeyChallenge(username: string, issuePlatformToken: boolean): Observable<MfaTokenResponse | null> {
+    if (this.isDemoMode()) {
+      return from(this.validatePasskeyDemo(username, issuePlatformToken));
+    }
+    return this.http.post<any>(`${mfaConfig().apiPath}/webauthn/assert/options`, { username }).pipe(
+      switchMap(async (options) => {
+        const assertion = await navigator.credentials.get({ publicKey: options.publicKey });
+        if (!assertion || assertion.type !== 'public-key') {
+          throw new Error('Passkey authentication was cancelled or failed.');
+        }
+        return assertion;
+      }),
+      switchMap((assertion) =>
+        this.http.post<MfaTokenResponse>(`${mfaConfig().apiPath}/challenge/webauthn`, {
+          username,
+          assertion
+        })
+      )
+    );
+  }
+
+  /**
+   * Passwordless passkey login. Demo mode restores the session handoff captured
+   * at enrollment; production expects the MFA server to return Fineract credentials.
+   */
+  loginWithPasskey(): Observable<PasskeyLoginResult> {
+    if (this.isDemoMode()) {
+      return from(this.loginWithPasskeyDemo());
+    }
+    return this.http.post<any>(`${mfaConfig().apiPath}/webauthn/assert/options`, { discoverable: true }).pipe(
+      switchMap(async (options) => {
+        const assertion = await navigator.credentials.get({ publicKey: options.publicKey });
+        if (!assertion || assertion.type !== 'public-key') {
+          throw new Error('Passkey authentication was cancelled or failed.');
+        }
+        return assertion;
+      }),
+      switchMap((assertion) =>
+        this.http.post<PasskeyLoginResult>(`${mfaConfig().apiPath}/passkey/login`, { assertion })
+      )
+    );
+  }
+
+  private async beginTotpSetupDemo(username: string): Promise<TotpSetupResponse> {
+    const setup = createTotpSetup(username);
+    await vaultSaveTotpSecret(username, tenantId(), setup.secret);
+    let qrDataUrl: string | undefined;
+    try {
+      qrDataUrl = await QRCode.toDataURL(setup.otpauthUri, { margin: 1, width: 220 });
+    } catch {
+      qrDataUrl = undefined;
+    }
+    return {
+      secret: setup.secret,
+      otpauthUri: setup.otpauthUri,
+      qrDataUrl
+    };
+  }
+
+  private async confirmTotpSetupDemo(username: string, code: string): Promise<void> {
+    const account = await vaultGetAccount(username, tenantId());
+    if (!account.totpSecret) {
+      throw new Error('No pending TOTP enrollment for this account.');
+    }
+    if (!verifyTotpCode(account.totpSecret, code)) {
+      throw new Error('Invalid authenticator code. Try again.');
+    }
+    await vaultConfirmTotp(username, tenantId());
+  }
+
+  private async validateTotpDemo(
+    username: string,
+    code: string,
+    issuePlatformToken: boolean
+  ): Promise<MfaTokenResponse | null> {
+    const account = await vaultGetAccount(username, tenantId());
+    if (!account.totpEnabled || !account.totpSecret) {
+      throw new Error('Authenticator app is not enabled for this account.');
+    }
+    if (!verifyTotpCode(account.totpSecret, code)) {
+      throw new Error('Invalid authenticator code.');
+    }
+    return issuePlatformToken ? demoToken() : null;
+  }
+
+  private async registerPasskeyDemo(
+    username: string,
+    displayName: string,
+    sessionCredentials?: Credentials
+  ): Promise<MfaPasskeyCredential> {
+    if (!isWebAuthnAvailable()) {
+      throw new Error('Passkeys are not supported in this browser.');
+    }
+    const credential = await createPasskey({
+      rpId: resolveRpId(),
+      rpName: mfaConfig().rpName,
+      userId: `${tenantId()}:${username}`,
+      userName: username,
+      userDisplayName: displayName || username
+    });
+    const response = credential.response as AuthenticatorAttestationResponse;
+    const summary: MfaPasskeyCredential = {
+      id: toBase64Url(credential.rawId),
+      name: displayName || 'Passkey',
+      createdAt: new Date().toISOString()
+    };
+    await vaultAddPasskey(
+      username,
+      tenantId(),
+      summary,
+      response.getPublicKey?.() ?? new ArrayBuffer(0),
+      sessionCredentials
+    );
+    return summary;
+  }
+
+  private async validatePasskeyDemo(
+    username: string,
+    issuePlatformToken: boolean
+  ): Promise<MfaTokenResponse | null> {
+    if (!isWebAuthnAvailable()) {
+      throw new Error('Passkeys are not supported in this browser.');
+    }
+    const status = await vaultGetStatus(username, tenantId());
+    if (!status.passkeys.length) {
+      throw new Error('No passkeys enrolled for this account.');
+    }
+    const assertion = await assertPasskey({
+      rpId: resolveRpId(),
+      allowCredentialIds: status.passkeys.map((p) => p.id)
+    });
+    const credentialId = toBase64Url(assertion.rawId);
+    if (!status.passkeys.some((p) => p.id === credentialId)) {
+      throw new Error('Unrecognized passkey.');
+    }
+    await vaultTouchPasskey(username, tenantId(), credentialId);
+    return issuePlatformToken ? demoToken() : null;
+  }
+
+  private async loginWithPasskeyDemo(): Promise<PasskeyLoginResult> {
+    if (!isWebAuthnAvailable()) {
+      throw new Error('Passkeys are not supported in this browser.');
+    }
+    const assertion = await assertPasskey({ rpId: resolveRpId() });
+    const credentialId = toBase64Url(assertion.rawId);
+    const row = await vaultFindByCredentialId(credentialId);
+    if (!row?.sessionHandoff?.credentials) {
+      throw new Error(
+        'No demo session is linked to this passkey. Sign in with password once, then register the passkey under Profile → Security.'
+      );
+    }
+    await vaultTouchPasskey(row.username, row.tenantId, credentialId);
+    // Refresh handoff so subsequent passwordless logins stay current in demo.
+    await vaultUpdateSessionHandoff(row.username, row.tenantId, row.sessionHandoff.credentials);
+    return {
+      credentials: {
+        ...row.sessionHandoff.credentials,
+        isTwoFactorAuthenticationRequired: false,
+        shouldRenewPassword: false
+      }
+    };
+  }
+}

--- a/src/app/core/mfa/mfa.service.ts
+++ b/src/app/core/mfa/mfa.service.ts
@@ -50,9 +50,10 @@ function resolveRpId(): string {
 }
 
 function demoToken(validSeconds = 3600): MfaTokenResponse {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
   const validTo = Date.now() + validSeconds * 1000;
   return {
-    token: `demo-mfa-${toBase64Url(crypto.getRandomValues(new Uint8Array(16)).buffer)}`,
+    token: `demo-mfa-${toBase64Url(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))}`,
     validTo,
     tokenLiveTimeInSec: validSeconds
   };
@@ -147,9 +148,11 @@ export class MfaService {
     if (this.isDemoMode()) {
       return from(vaultRemovePasskey(username, tenantId(), credentialId));
     }
-    return this.http.delete<void>(`${mfaConfig().apiPath}/webauthn/credentials/${encodeURIComponent(credentialId)}`, {
-      body: { username }
-    });
+    return this.http.request<void>(
+      'DELETE',
+      `${mfaConfig().apiPath}/webauthn/credentials/${encodeURIComponent(credentialId)}`,
+      { body: { username } }
+    );
   }
 
   validateTotpChallenge(username: string, code: string, issuePlatformToken: boolean): Observable<MfaTokenResponse | null> {

--- a/src/app/core/mfa/totp.util.spec.ts
+++ b/src/app/core/mfa/totp.util.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { createTotpSetup, verifyTotpCode } from './totp.util';
+
+describe('totp.util', () => {
+  it('creates a setup secret and verifies a matching code', () => {
+    const setup = createTotpSetup('mifos');
+    expect(setup.secret.length).toBeGreaterThan(10);
+    expect(setup.otpauthUri).toContain('otpauth://totp/');
+    expect(setup.otpauthUri).toContain('Mifos%20X');
+
+    const code = setup.totp.generate();
+    expect(verifyTotpCode(setup.secret, code)).toBe(true);
+    expect(verifyTotpCode(setup.secret, '000000')).toBe(false);
+  });
+});

--- a/src/app/core/mfa/totp.util.ts
+++ b/src/app/core/mfa/totp.util.ts
@@ -1,0 +1,39 @@
+import { TOTP, Secret } from 'otpauth';
+
+/** Issuer shown in authenticator apps. */
+export const TOTP_ISSUER = 'Mifos X';
+
+/**
+ * Creates a new TOTP secret and otpauth URI for enrollment.
+ */
+export function createTotpSetup(username: string): { secret: string; otpauthUri: string; totp: TOTP } {
+  const secret = new Secret({ size: 20 });
+  const totp = new TOTP({
+    issuer: TOTP_ISSUER,
+    label: username,
+    algorithm: 'SHA1',
+    digits: 6,
+    period: 30,
+    secret,
+  });
+  return {
+    secret: secret.base32,
+    otpauthUri: totp.toString(),
+    totp,
+  };
+}
+
+/**
+ * Validates a TOTP code against a base32 secret.
+ */
+export function verifyTotpCode(secretBase32: string, code: string, window = 1): boolean {
+  const totp = new TOTP({
+    issuer: TOTP_ISSUER,
+    algorithm: 'SHA1',
+    digits: 6,
+    period: 30,
+    secret: Secret.fromBase32(secretBase32),
+  });
+  const delta = totp.validate({ token: code.replace(/\s/g, ''), window });
+  return delta !== null;
+}

--- a/src/app/core/mfa/webauthn.util.spec.ts
+++ b/src/app/core/mfa/webauthn.util.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { isWebAuthnAvailable, toBase64Url, fromBase64Url, randomChallenge } from './webauthn.util';
+
+describe('webauthn.util', () => {
+  it('round-trips base64url buffers', () => {
+    const original = randomChallenge(16);
+    const encoded = toBase64Url(original.buffer);
+    const decoded = new Uint8Array(fromBase64Url(encoded));
+    expect(Array.from(decoded)).toEqual(Array.from(original));
+  });
+
+  it('reports WebAuthn availability based on browser APIs', () => {
+    expect(typeof isWebAuthnAvailable()).toBe('boolean');
+  });
+});

--- a/src/app/core/mfa/webauthn.util.ts
+++ b/src/app/core/mfa/webauthn.util.ts
@@ -21,7 +21,7 @@ function base64UrlToBuffer(base64url: string): ArrayBuffer {
   return buffer;
 }
 
-export function randomChallenge(byteLength = 32): Uint8Array {
+export function randomChallenge(byteLength = 32): Uint8Array<ArrayBuffer> {
   const challenge = new Uint8Array(byteLength);
   crypto.getRandomValues(challenge);
   return challenge;

--- a/src/app/core/mfa/webauthn.util.ts
+++ b/src/app/core/mfa/webauthn.util.ts
@@ -1,0 +1,110 @@
+/**
+ * WebAuthn / passkey helpers (browser APIs).
+ */
+
+function bufferToBase64Url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let str = '';
+  bytes.forEach((b) => { str += String.fromCharCode(b); });
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlToBuffer(base64url: string): ArrayBuffer {
+  const pad = '='.repeat((4 - (base64url.length % 4)) % 4);
+  const base64 = (base64url + pad).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const buffer = new ArrayBuffer(raw.length);
+  const view = new Uint8Array(buffer);
+  for (let i = 0; i < raw.length; i++) {
+    view[i] = raw.charCodeAt(i);
+  }
+  return buffer;
+}
+
+export function randomChallenge(byteLength = 32): Uint8Array {
+  const challenge = new Uint8Array(byteLength);
+  crypto.getRandomValues(challenge);
+  return challenge;
+}
+
+export function toBase64Url(buffer: ArrayBuffer): string {
+  return bufferToBase64Url(buffer);
+}
+
+export function fromBase64Url(value: string): ArrayBuffer {
+  return base64UrlToBuffer(value);
+}
+
+export function isWebAuthnAvailable(): boolean {
+  return typeof window !== 'undefined'
+    && !!window.PublicKeyCredential
+    && typeof navigator.credentials?.create === 'function'
+    && typeof navigator.credentials?.get === 'function';
+}
+
+/**
+ * Registers a new platform/roaming passkey.
+ */
+export async function createPasskey(options: {
+  rpId: string;
+  rpName: string;
+  userId: string;
+  userName: string;
+  userDisplayName: string;
+}): Promise<PublicKeyCredential> {
+  const userIdBytes = new TextEncoder().encode(options.userId);
+  const credential = await navigator.credentials.create({
+    publicKey: {
+      challenge: randomChallenge(),
+      rp: { id: options.rpId, name: options.rpName },
+      user: {
+        id: userIdBytes,
+        name: options.userName,
+        displayName: options.userDisplayName,
+      },
+      pubKeyCredParams: [
+        { type: 'public-key', alg: -7 },
+        { type: 'public-key', alg: -257 },
+      ],
+      authenticatorSelection: {
+        authenticatorAttachment: 'platform',
+        userVerification: 'preferred',
+        residentKey: 'preferred',
+        requireResidentKey: false,
+      },
+      timeout: 60_000,
+      attestation: 'none',
+    },
+  });
+  if (!credential || credential.type !== 'public-key') {
+    throw new Error('Passkey registration was cancelled or failed.');
+  }
+  return credential as PublicKeyCredential;
+}
+
+/**
+ * Asserts an existing passkey (login / MFA).
+ */
+export async function assertPasskey(options: {
+  rpId: string;
+  allowCredentialIds?: string[];
+}): Promise<PublicKeyCredential> {
+  const allowCredentials = (options.allowCredentialIds ?? []).map((id) => ({
+    type: 'public-key' as const,
+    id: fromBase64Url(id),
+  }));
+
+  const credential = await navigator.credentials.get({
+    publicKey: {
+      challenge: randomChallenge(),
+      rpId: options.rpId,
+      allowCredentials: allowCredentials.length ? allowCredentials : undefined,
+      userVerification: 'preferred',
+      timeout: 60_000,
+    },
+  });
+  if (!credential || credential.type !== 'public-key') {
+    throw new Error('Passkey authentication was cancelled or failed.');
+  }
+  return credential as PublicKeyCredential;
+}

--- a/src/app/login/login-form/login-form.component.html
+++ b/src/app/login/login-form/login-form.component.html
@@ -5,7 +5,7 @@
       <fa-icon icon="user-circle" size="lg"></fa-icon>&nbsp;&nbsp;
     </span>
     <mat-label>Username</mat-label>
-    <input matInput type="text" autocomplete="off" formControlName="username">
+    <input matInput type="text" autocomplete="username" formControlName="username">
     <mat-error *ngIf="loginForm.controls.username.hasError('required')">
       Username is <strong>required</strong>
     </mat-error>
@@ -16,8 +16,8 @@
       <fa-icon icon="lock" size="lg"></fa-icon>&nbsp;&nbsp;
     </span>
     <mat-label>Password</mat-label>
-    <input matInput type="{{ passwordInputType }}" formControlName="password">
-    <button *ngIf="loginForm.controls.password.value && !loading" matSuffix mat-icon-button
+    <input matInput type="{{ passwordInputType }}" autocomplete="current-password" formControlName="password">
+    <button *ngIf="loginForm.controls.password.value && !loading" matSuffix mat-icon-button type="button"
       (mousedown)="passwordInputType = 'text'" (mouseup)="passwordInputType = 'password'">
       <fa-icon *ngIf="passwordInputType === 'password'" icon="eye"></fa-icon>
       <fa-icon *ngIf="passwordInputType === 'text'" icon="eye-slash"></fa-icon>
@@ -37,5 +37,18 @@
   <button type="button" mat-button fxFlexAlign="center" class="login-button" (click)="forgotPassword()" [disabled]="loading">
     Forgot Password?
   </button>
+
+  <ng-container *ngIf="passkeysSupported">
+    <mat-divider fxFlexAlign="center" class="login-divider"></mat-divider>
+
+    <button type="button" mat-stroked-button color="primary" fxFlexAlign="center" class="login-button"
+      id="passkey-login-button"
+      (click)="loginWithPasskey()" [disabled]="loading || passkeyLoading">
+      <fa-icon icon="key"></fa-icon>&nbsp;&nbsp;Sign in with passkey
+      <mat-spinner [diameter]="20" *ngIf="passkeyLoading"></mat-spinner>
+    </button>
+
+    <p *ngIf="passkeyError" class="passkey-error" fxFlexAlign="center">{{ passkeyError }}</p>
+  </ng-container>
 
 </form>

--- a/src/app/login/login-form/login-form.component.scss
+++ b/src/app/login/login-form/login-form.component.scss
@@ -9,6 +9,18 @@
     margin-top: 1rem;
   }
 
+  .login-divider {
+    width: 14rem;
+    margin: 1rem 0 0;
+  }
+
+  .passkey-error {
+    color: #b71c1c;
+    max-width: 14rem;
+    text-align: center;
+    margin-top: 0.5rem;
+  }
+
   mat-spinner {
     float: right;
     margin: 0.5rem 0;

--- a/src/app/login/login-form/login-form.component.ts
+++ b/src/app/login/login-form/login-form.component.ts
@@ -7,6 +7,8 @@ import { finalize } from 'rxjs/operators';
 
 /** Custom Services */
 import { AuthenticationService } from '../../core/authentication/authentication.service';
+import { MfaService } from '../../core/mfa/mfa.service';
+import { environment } from '../../../environments/environment';
 import { LayoutDirective, FlexAlignDirective } from '@ngbracket/ngx-layout/flex';
 import { MatFormField, MatPrefix, MatLabel, MatError, MatSuffix } from '@angular/material/form-field';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -15,6 +17,7 @@ import { NgIf } from '@angular/common';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { MatDivider } from '@angular/material/divider';
 
 /**
  * Login form component.
@@ -24,7 +27,11 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
     templateUrl: './login-form.component.html',
     changeDetection: ChangeDetectionStrategy.Eager,
     styleUrls: ['./login-form.component.scss'],
-    imports: [ReactiveFormsModule, LayoutDirective, MatFormField, FlexAlignDirective, MatPrefix, FaIconComponent, MatLabel, MatInput, NgIf, MatError, MatButton, MatIconButton, MatSuffix, MatCheckbox, MatProgressSpinner]
+    imports: [
+      ReactiveFormsModule, LayoutDirective, MatFormField, FlexAlignDirective, MatPrefix, FaIconComponent,
+      MatLabel, MatInput, NgIf, MatError, MatButton, MatIconButton, MatSuffix, MatCheckbox, MatProgressSpinner,
+      MatDivider
+    ]
 })
 export class LoginFormComponent implements OnInit {
 
@@ -34,50 +41,56 @@ export class LoginFormComponent implements OnInit {
   passwordInputType: string;
   /** True if loading. */
   loading = false;
+  /** True while a passkey ceremony is in progress. */
+  passkeyLoading = false;
+  /** Passkey availability. */
+  passkeysSupported = false;
+  /** Passkey login error. */
+  passkeyError = '';
+  /** MFA demo note (local vault). */
+  mfaDemoMode = environment.mfa?.demoMode;
 
-  /**
-   * @param {FormBuilder} formBuilder Form Builder.
-   * @param {AuthenticationService} authenticationService Authentication Service.
-   */
   constructor(private formBuilder: FormBuilder,
-              private authenticationService: AuthenticationService) {  }
+              private authenticationService: AuthenticationService,
+              private mfaService: MfaService) {  }
 
-  /**
-   * Creates login form.
-   *
-   * Initializes password input field type.
-   */
   ngOnInit() {
     this.createLoginForm();
     this.passwordInputType = 'password';
+    this.passkeysSupported = this.mfaService.webAuthnAvailable();
   }
 
-  /**
-   * Authenticates the user if the credentials are valid.
-   */
   login() {
     this.loading = true;
+    this.passkeyError = '';
     this.loginForm.disable();
     this.authenticationService.login(this.loginForm.value)
       .pipe(finalize(() => {
         this.loginForm.reset();
         this.loginForm.markAsPristine();
-        // Angular Material Bug: Validation errors won't get removed on reset.
         this.loginForm.enable();
         this.loading = false;
       })).subscribe();
   }
 
-  /**
-   * TODO: Decision to be taken on providing this feature.
-   */
+  loginWithPasskey() {
+    this.passkeyError = '';
+    this.passkeyLoading = true;
+    this.authenticationService.loginWithPasskey()
+      .pipe(finalize(() => {
+        this.passkeyLoading = false;
+      }))
+      .subscribe({
+        error: (err) => {
+          this.passkeyError = err?.message || 'Passkey sign-in failed.';
+        }
+      });
+  }
+
   forgotPassword() {
     console.log('Forgot Password feature currently unavailable.');
   }
 
-  /**
-   * Creates login form.
-   */
   private createLoginForm() {
     this.loginForm = this.formBuilder.group({
       'username': ['', Validators.required],

--- a/src/app/login/two-factor-authentication/two-factor-authentication.component.html
+++ b/src/app/login/two-factor-authentication/two-factor-authentication.component.html
@@ -1,11 +1,79 @@
-<p><strong>Two Factor Authentication</strong></p>
+<p><strong>Multi-Factor Authentication</strong></p>
 
 <mat-divider></mat-divider>
 
-<!-- Select delivery method to receive OTP -->
-<p *ngIf="!otpRequested">Please select a delivery method:</p>
+<p class="mfa-error" *ngIf="errorMessage">{{ errorMessage }}</p>
 
-<form fxLayout="column" *ngIf="!otpRequested" [formGroup]="twoFactorAuthenticationDeliveryMethodForm" class="two-factor-auth-form"
+<!-- Method chooser when more than one option is available -->
+<div fxLayout="column" *ngIf="view === 'choose'" class="two-factor-auth-form">
+  <p>Choose how to verify your identity:</p>
+
+  <mat-button-toggle-group fxFlexAlign="center" class="mfa-method-toggle">
+    <mat-button-toggle *ngIf="hasTotp" (click)="selectView('totp')" value="totp">
+      Authenticator app
+    </mat-button-toggle>
+    <mat-button-toggle *ngIf="hasPasskey" (click)="selectView('passkey')" value="passkey">
+      Passkey
+    </mat-button-toggle>
+    <mat-button-toggle *ngIf="hasLegacyDelivery" (click)="selectView('legacy-delivery')" value="legacy">
+      SMS / Email OTP
+    </mat-button-toggle>
+  </mat-button-toggle-group>
+</div>
+
+<!-- TOTP authenticator -->
+<form fxLayout="column" *ngIf="view === 'totp'" [formGroup]="totpForm" class="two-factor-auth-form"
+  (ngSubmit)="validateTotp()">
+  <p>Enter the 6-digit code from your authenticator app.</p>
+
+  <mat-form-field fxFlexAlign="center" class="two-factor-auth-input">
+    <span matPrefix>
+      <fa-icon icon="user-shield"></fa-icon>&nbsp;&nbsp;
+    </span>
+    <mat-label>Authenticator code</mat-label>
+    <input type="text" inputmode="numeric" autocomplete="one-time-code" matInput required formControlName="code"
+      maxlength="6">
+    <mat-error *ngIf="totpForm.controls.code.hasError('required')">
+      Code is <strong>required</strong>
+    </mat-error>
+    <mat-error *ngIf="totpForm.controls.code.hasError('pattern')">
+      Enter a <strong>6-digit</strong> code
+    </mat-error>
+  </mat-form-field>
+
+  <button mat-raised-button color="primary" fxFlexAlign="center" class="two-factor-auth-button"
+    [disabled]="!totpForm.valid || loading">
+    Verify
+    <mat-spinner [diameter]="20" *ngIf="loading"></mat-spinner>
+  </button>
+
+  <button type="button" mat-button fxFlexAlign="center" *ngIf="hasPasskey || hasLegacyDelivery"
+    (click)="selectView('choose')">
+    Use another method
+  </button>
+</form>
+
+<!-- Passkey challenge -->
+<div fxLayout="column" *ngIf="view === 'passkey'" class="two-factor-auth-form">
+  <p>Use your device passkey to continue.</p>
+
+  <button mat-raised-button color="primary" fxFlexAlign="center" class="two-factor-auth-button"
+    (click)="validatePasskey()" [disabled]="loading">
+    <fa-icon icon="key"></fa-icon>&nbsp;&nbsp;Continue with passkey
+    <mat-spinner [diameter]="20" *ngIf="loading"></mat-spinner>
+  </button>
+
+  <button type="button" mat-button fxFlexAlign="center" *ngIf="hasTotp || hasLegacyDelivery"
+    (click)="selectView('choose')">
+    Use another method
+  </button>
+</div>
+
+<!-- Select delivery method to receive OTP -->
+<p *ngIf="view === 'legacy-delivery' && !otpRequested">Please select a delivery method:</p>
+
+<form fxLayout="column" *ngIf="view === 'legacy-delivery' && !otpRequested"
+  [formGroup]="twoFactorAuthenticationDeliveryMethodForm" class="two-factor-auth-form"
   (ngSubmit)="requestOTP()">
 
   <mat-radio-group fxLayout="column" fxFlexAlign="center" formControlName="twoFactorAuthenticationDeliveryMethod">
@@ -15,17 +83,23 @@
     </mat-radio-button>
   </mat-radio-group>
 
-  <button mat-raised-button color="primary" fxFlexAlign="center" fxFlexFill [disabled]="!twoFactorAuthenticationDeliveryMethodForm.valid">
+  <button mat-raised-button color="primary" fxFlexAlign="center" fxFlexFill
+    [disabled]="!twoFactorAuthenticationDeliveryMethodForm.valid || loading">
     Request OTP
     <mat-spinner [diameter]="20" *ngIf="loading"></mat-spinner>
+  </button>
+
+  <button type="button" mat-button fxFlexAlign="center" *ngIf="hasTotp || hasPasskey"
+    (click)="selectView('choose')">
+    Use another method
   </button>
 
 </form>
 
 <!-- Show input for OTP -->
-<p *ngIf="otpRequested">Please enter the OTP:</p>
+<p *ngIf="view === 'legacy-otp'">Please enter the OTP:</p>
 
-<form fxLayout="column" *ngIf="otpRequested" [formGroup]="twoFactorAuthenticationForm" class="two-factor-auth-form"
+<form fxLayout="column" *ngIf="view === 'legacy-otp'" [formGroup]="twoFactorAuthenticationForm" class="two-factor-auth-form"
   (ngSubmit)="validateOTP()">
 
   <mat-form-field fxFlexAlign="center" class="two-factor-auth-input">

--- a/src/app/login/two-factor-authentication/two-factor-authentication.component.html
+++ b/src/app/login/two-factor-authentication/two-factor-authentication.component.html
@@ -4,21 +4,30 @@
 
 <p class="mfa-error" *ngIf="errorMessage">{{ errorMessage }}</p>
 
+<div fxLayout="column" *ngIf="view === 'loading'" class="two-factor-auth-form" fxLayoutAlign="center center">
+  <mat-spinner [diameter]="32"></mat-spinner>
+  <p>Loading verification methods…</p>
+</div>
+
+<div fxLayout="column" *ngIf="view === 'unavailable'" class="two-factor-auth-form">
+  <p>No verification methods are available for this account. Contact your administrator.</p>
+</div>
+
 <!-- Method chooser when more than one option is available -->
 <div fxLayout="column" *ngIf="view === 'choose'" class="two-factor-auth-form">
   <p>Choose how to verify your identity:</p>
 
-  <mat-button-toggle-group fxFlexAlign="center" class="mfa-method-toggle">
-    <mat-button-toggle *ngIf="hasTotp" (click)="selectView('totp')" value="totp">
-      Authenticator app
-    </mat-button-toggle>
-    <mat-button-toggle *ngIf="hasPasskey" (click)="selectView('passkey')" value="passkey">
-      Passkey
-    </mat-button-toggle>
-    <mat-button-toggle *ngIf="hasLegacyDelivery" (click)="selectView('legacy-delivery')" value="legacy">
+  <div fxLayout="column" fxFlexAlign="center" fxLayoutGap="0.5rem">
+    <button mat-stroked-button type="button" *ngIf="hasTotp" (click)="selectView('totp')" id="mfa-choose-totp">
+      <fa-icon icon="user-shield"></fa-icon>&nbsp;&nbsp;Authenticator app
+    </button>
+    <button mat-stroked-button type="button" *ngIf="hasPasskey" (click)="selectView('passkey')" id="mfa-choose-passkey">
+      <fa-icon icon="key"></fa-icon>&nbsp;&nbsp;Passkey
+    </button>
+    <button mat-stroked-button type="button" *ngIf="hasLegacyDelivery" (click)="selectView('legacy-delivery')" id="mfa-choose-otp">
       SMS / Email OTP
-    </mat-button-toggle>
-  </mat-button-toggle-group>
+    </button>
+  </div>
 </div>
 
 <!-- TOTP authenticator -->
@@ -42,6 +51,7 @@
   </mat-form-field>
 
   <button mat-raised-button color="primary" fxFlexAlign="center" class="two-factor-auth-button"
+    type="submit" id="mfa-totp-verify"
     [disabled]="!totpForm.valid || loading">
     Verify
     <mat-spinner [diameter]="20" *ngIf="loading"></mat-spinner>

--- a/src/app/login/two-factor-authentication/two-factor-authentication.component.scss
+++ b/src/app/login/two-factor-authentication/two-factor-authentication.component.scss
@@ -20,4 +20,14 @@
     float: right;
     margin: 0.5rem 0;
   }
+
+  .mfa-method-toggle {
+    margin-bottom: 1rem;
+  }
+}
+
+.mfa-error {
+  color: #b71c1c;
+  max-width: 16rem;
+  text-align: center;
 }

--- a/src/app/login/two-factor-authentication/two-factor-authentication.component.ts
+++ b/src/app/login/two-factor-authentication/two-factor-authentication.component.ts
@@ -7,6 +7,8 @@ import { finalize } from 'rxjs/operators';
 
 /** Custom Services */
 import { AuthenticationService } from '../../core/authentication/authentication.service';
+import { MfaService } from '../../core/mfa/mfa.service';
+import { MfaStatus } from '../../core/mfa/mfa.models';
 import { MatDivider } from '@angular/material/divider';
 import { NgIf, NgFor } from '@angular/common';
 import { LayoutDirective, FlexAlignDirective, FlexFillDirective } from '@ngbracket/ngx-layout/flex';
@@ -16,21 +18,30 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatFormField, MatPrefix, MatLabel, MatHint, MatError } from '@angular/material/form-field';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatInput } from '@angular/material/input';
+import { MatButtonToggleGroup, MatButtonToggle } from '@angular/material/button-toggle';
+
+type ChallengeView = 'choose' | 'legacy-delivery' | 'legacy-otp' | 'totp' | 'passkey';
 
 /**
- * Two factor authentication component.
+ * Two factor / MFA authentication component.
+ * Supports legacy Fineract SMS/email OTP, TOTP authenticator codes, and passkeys.
  */
 @Component({
     selector: 'mifosx-two-factor-authentication',
     templateUrl: './two-factor-authentication.component.html',
     changeDetection: ChangeDetectionStrategy.Eager,
     styleUrls: ['./two-factor-authentication.component.scss'],
-    imports: [MatDivider, NgIf, ReactiveFormsModule, LayoutDirective, MatRadioGroup, FlexAlignDirective, NgFor, MatRadioButton, MatButton, FlexFillDirective, MatProgressSpinner, MatFormField, MatPrefix, FaIconComponent, MatLabel, MatInput, MatHint, MatError]
+    imports: [
+      MatDivider, NgIf, ReactiveFormsModule, LayoutDirective, MatRadioGroup, FlexAlignDirective,
+      NgFor, MatRadioButton, MatButton, FlexFillDirective, MatProgressSpinner, MatFormField,
+      MatPrefix, FaIconComponent, MatLabel, MatInput, MatHint, MatError,
+      MatButtonToggleGroup, MatButtonToggle
+    ]
 })
 export class TwoFactorAuthenticationComponent implements OnInit {
 
   /** Available delivery methods to receive OTP. */
-  twoFactorAuthenticationDeliveryMethods: any;
+  twoFactorAuthenticationDeliveryMethods: any[] = [];
   /** Delivery method selected to receive OTP. */
   selectedTwoFactorAuthenticationDeliveryMethod: any;
   /** True if OTP is requested. */
@@ -41,34 +52,77 @@ export class TwoFactorAuthenticationComponent implements OnInit {
   twoFactorAuthenticationDeliveryMethodForm: FormGroup;
   /** Two factor authentication form group. */
   twoFactorAuthenticationForm: FormGroup;
+  /** TOTP challenge form. */
+  totpForm: FormGroup;
   /** True if loading. */
   loading = false;
   /** True if loading. */
   resendOTPLoading = false;
+  /** App MFA status for the pending user. */
+  mfaStatus: MfaStatus | null = null;
+  /** Active challenge view. */
+  view: ChallengeView = 'choose';
+  /** Error message for MFA failures. */
+  errorMessage = '';
+  /** Whether passkeys are usable in this browser. */
+  passkeysSupported = false;
 
-  /**
-   * @param {FormBuilder} formBuilder Form Builder.
-   * @param {AuthenticationService} authenticationService Authentication Service.
-   */
-  constructor(private formBuilder: FormBuilder,
-              private authenticationService: AuthenticationService) {  }
+  constructor(
+    private formBuilder: FormBuilder,
+    private authenticationService: AuthenticationService,
+    private mfaService: MfaService
+  ) { }
 
-  /**
-   * Creates two factor authentication delivery method form.
-   *
-   * Gets the delivery methods available to receive OTP.
-   */
   ngOnInit() {
     this.createTwoFactorAuthenticationDeliveryMethodForm();
+    this.createTotpForm();
+    this.passkeysSupported = this.mfaService.webAuthnAvailable();
+
+    const pending = this.authenticationService.getPendingCredentials();
+    if (pending?.username) {
+      this.mfaService.getStatus(pending.username).subscribe({
+        next: (status) => {
+          this.mfaStatus = status;
+          this.bootstrapView();
+        },
+        error: () => this.bootstrapView()
+      });
+    } else {
+      this.bootstrapView();
+    }
+
     this.authenticationService.getDeliveryMethods()
-      .subscribe((deliveryMethods: any) => {
-        this.twoFactorAuthenticationDeliveryMethods = deliveryMethods;
+      .subscribe({
+        next: (deliveryMethods: any) => {
+          this.twoFactorAuthenticationDeliveryMethods = Array.isArray(deliveryMethods)
+            ? deliveryMethods
+            : (deliveryMethods ?? []);
+          this.bootstrapView();
+        },
+        error: () => {
+          this.twoFactorAuthenticationDeliveryMethods = [];
+          this.bootstrapView();
+        }
       });
   }
 
-  /**
-   * Requests OTP via the selected delivery method.
-   */
+  get hasTotp(): boolean {
+    return !!this.mfaStatus?.totpEnabled;
+  }
+
+  get hasPasskey(): boolean {
+    return (this.mfaStatus?.passkeys?.length ?? 0) > 0 && this.passkeysSupported;
+  }
+
+  get hasLegacyDelivery(): boolean {
+    return this.twoFactorAuthenticationDeliveryMethods.length > 0;
+  }
+
+  selectView(view: ChallengeView): void {
+    this.errorMessage = '';
+    this.view = view;
+  }
+
   requestOTP() {
     this.loading = true;
     this.twoFactorAuthenticationDeliveryMethodForm.disable();
@@ -79,20 +133,17 @@ export class TwoFactorAuthenticationComponent implements OnInit {
       .pipe(finalize(() => {
         this.twoFactorAuthenticationDeliveryMethodForm.reset();
         this.twoFactorAuthenticationDeliveryMethodForm.markAsPristine();
-        // Angular Material Bug: Validation errors won't get removed on reset.
         this.twoFactorAuthenticationDeliveryMethodForm.enable();
         this.loading = false;
       }))
       .subscribe((response: any) => {
         this.createTwoFactorAuthenticationForm();
         this.otpRequested = true;
+        this.view = 'legacy-otp';
         this.tokenValidityTime = response.tokenLiveTimeInSec;
       });
   }
 
-  /**
-   * Validates the OTP and authenticates the user.
-   */
   validateOTP() {
     this.loading = true;
     this.twoFactorAuthenticationForm.disable();
@@ -100,15 +151,11 @@ export class TwoFactorAuthenticationComponent implements OnInit {
       .pipe(finalize(() => {
         this.twoFactorAuthenticationForm.reset();
         this.twoFactorAuthenticationForm.markAsPristine();
-        // Angular Material Bug: Validation errors won't get removed on reset.
         this.twoFactorAuthenticationForm.enable();
         this.loading = false;
       })).subscribe();
   }
 
-  /**
-   * Resends OTP via the selected delivery method.
-   */
   resendOTP() {
     this.resendOTPLoading = true;
     this.twoFactorAuthenticationForm.disable();
@@ -116,27 +163,77 @@ export class TwoFactorAuthenticationComponent implements OnInit {
       .pipe(finalize(() => {
         this.twoFactorAuthenticationForm.reset();
         this.twoFactorAuthenticationForm.markAsPristine();
-        // Angular Material Bug: Validation errors won't get removed on reset.
         this.twoFactorAuthenticationForm.enable();
         this.resendOTPLoading = false;
       })).subscribe();
   }
 
-  /**
-   * Creates two factor authentication delivery method form.
-   */
+  validateTotp() {
+    this.errorMessage = '';
+    this.loading = true;
+    this.totpForm.disable();
+    this.authenticationService.validateTotpChallenge(this.totpForm.value.code)
+      .pipe(finalize(() => {
+        this.totpForm.reset();
+        this.totpForm.markAsPristine();
+        this.totpForm.enable();
+        this.loading = false;
+      }))
+      .subscribe({
+        error: (err) => {
+          this.errorMessage = err?.message || 'Invalid authenticator code.';
+        }
+      });
+  }
+
+  validatePasskey() {
+    this.errorMessage = '';
+    this.loading = true;
+    this.authenticationService.validatePasskeyChallenge()
+      .pipe(finalize(() => {
+        this.loading = false;
+      }))
+      .subscribe({
+        error: (err) => {
+          this.errorMessage = err?.message || 'Passkey authentication failed.';
+        }
+      });
+  }
+
+  private bootstrapView(): void {
+    const options = [
+      this.hasTotp ? 'totp' : null,
+      this.hasPasskey ? 'passkey' : null,
+      this.hasLegacyDelivery ? 'legacy-delivery' : null
+    ].filter(Boolean) as ChallengeView[];
+
+    if (options.length === 1) {
+      this.view = options[0] === 'legacy-delivery' ? 'legacy-delivery' : options[0];
+      return;
+    }
+    if (options.length > 1) {
+      this.view = 'choose';
+      return;
+    }
+    // Fineract required 2FA but no methods yet — keep legacy delivery form ready.
+    this.view = 'legacy-delivery';
+  }
+
   private createTwoFactorAuthenticationDeliveryMethodForm() {
     this.twoFactorAuthenticationDeliveryMethodForm = this.formBuilder.group({
       'twoFactorAuthenticationDeliveryMethod': ['', Validators.required]
     });
   }
 
-  /**
-   * Creates two factor authentication form.
-   */
   private createTwoFactorAuthenticationForm() {
     this.twoFactorAuthenticationForm = this.formBuilder.group({
       'otp': ['', Validators.required]
+    });
+  }
+
+  private createTotpForm() {
+    this.totpForm = this.formBuilder.group({
+      'code': ['', [Validators.required, Validators.pattern(/^\d{6}$/)]]
     });
   }
 

--- a/src/app/login/two-factor-authentication/two-factor-authentication.component.ts
+++ b/src/app/login/two-factor-authentication/two-factor-authentication.component.ts
@@ -3,7 +3,8 @@ import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 
 /** rxjs Imports */
-import { finalize } from 'rxjs/operators';
+import { of } from 'rxjs';
+import { catchError, finalize, timeout } from 'rxjs/operators';
 
 /** Custom Services */
 import { AuthenticationService } from '../../core/authentication/authentication.service';
@@ -11,16 +12,15 @@ import { MfaService } from '../../core/mfa/mfa.service';
 import { MfaStatus } from '../../core/mfa/mfa.models';
 import { MatDivider } from '@angular/material/divider';
 import { NgIf, NgFor } from '@angular/common';
-import { LayoutDirective, FlexAlignDirective, FlexFillDirective } from '@ngbracket/ngx-layout/flex';
+import { LayoutDirective, FlexAlignDirective, FlexFillDirective, LayoutGapDirective } from '@ngbracket/ngx-layout/flex';
 import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
 import { MatButton } from '@angular/material/button';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatFormField, MatPrefix, MatLabel, MatHint, MatError } from '@angular/material/form-field';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatInput } from '@angular/material/input';
-import { MatButtonToggleGroup, MatButtonToggle } from '@angular/material/button-toggle';
 
-type ChallengeView = 'choose' | 'legacy-delivery' | 'legacy-otp' | 'totp' | 'passkey';
+type ChallengeView = 'loading' | 'choose' | 'legacy-delivery' | 'legacy-otp' | 'totp' | 'passkey' | 'unavailable';
 
 /**
  * Two factor / MFA authentication component.
@@ -29,13 +29,12 @@ type ChallengeView = 'choose' | 'legacy-delivery' | 'legacy-otp' | 'totp' | 'pas
 @Component({
     selector: 'mifosx-two-factor-authentication',
     templateUrl: './two-factor-authentication.component.html',
-    changeDetection: ChangeDetectionStrategy.Eager,
+    changeDetection: ChangeDetectionStrategy.Default,
     styleUrls: ['./two-factor-authentication.component.scss'],
     imports: [
-      MatDivider, NgIf, ReactiveFormsModule, LayoutDirective, MatRadioGroup, FlexAlignDirective,
+      MatDivider, NgIf, ReactiveFormsModule, LayoutDirective, LayoutGapDirective, MatRadioGroup, FlexAlignDirective,
       NgFor, MatRadioButton, MatButton, FlexFillDirective, MatProgressSpinner, MatFormField,
-      MatPrefix, FaIconComponent, MatLabel, MatInput, MatHint, MatError,
-      MatButtonToggleGroup, MatButtonToggle
+      MatPrefix, FaIconComponent, MatLabel, MatInput, MatHint, MatError
     ]
 })
 export class TwoFactorAuthenticationComponent implements OnInit {
@@ -61,7 +60,7 @@ export class TwoFactorAuthenticationComponent implements OnInit {
   /** App MFA status for the pending user. */
   mfaStatus: MfaStatus | null = null;
   /** Active challenge view. */
-  view: ChallengeView = 'choose';
+  view: ChallengeView = 'loading';
   /** Error message for MFA failures. */
   errorMessage = '';
   /** Whether passkeys are usable in this browser. */
@@ -78,32 +77,43 @@ export class TwoFactorAuthenticationComponent implements OnInit {
     this.createTotpForm();
     this.passkeysSupported = this.mfaService.webAuthnAvailable();
 
-    const pending = this.authenticationService.getPendingCredentials();
-    if (pending?.username) {
-      this.mfaService.getStatus(pending.username).subscribe({
-        next: (status) => {
-          this.mfaStatus = status;
-          this.bootstrapView();
-        },
-        error: () => this.bootstrapView()
-      });
-    } else {
-      this.bootstrapView();
+    // Prefer status already resolved during login (demo vault / HTTP).
+    const cached = this.authenticationService.getPendingMfaStatus();
+    if (cached) {
+      this.mfaStatus = cached;
     }
 
     this.authenticationService.getDeliveryMethods()
-      .subscribe({
-        next: (deliveryMethods: any) => {
-          this.twoFactorAuthenticationDeliveryMethods = Array.isArray(deliveryMethods)
-            ? deliveryMethods
-            : (deliveryMethods ?? []);
-          this.bootstrapView();
-        },
-        error: () => {
-          this.twoFactorAuthenticationDeliveryMethods = [];
-          this.bootstrapView();
-        }
+      .pipe(
+        timeout({ first: 2000 }),
+        catchError(() => of([]))
+      )
+      .subscribe((deliveryMethods: any) => {
+        this.twoFactorAuthenticationDeliveryMethods = Array.isArray(deliveryMethods)
+          ? deliveryMethods
+          : [];
+        this.bootstrapView();
       });
+
+    if (!this.mfaStatus) {
+      const pending = this.authenticationService.getPendingCredentials();
+      if (pending?.username) {
+        this.mfaService.getStatus(pending.username)
+          .pipe(
+            timeout({ first: 2000 }),
+            catchError(() => of({ totpEnabled: false, passkeys: [], methods: [] } as MfaStatus))
+          )
+          .subscribe((status) => {
+            this.mfaStatus = status;
+            this.bootstrapView();
+          });
+      } else {
+        this.mfaStatus = { totpEnabled: false, passkeys: [], methods: [] };
+        this.bootstrapView();
+      }
+    } else {
+      this.bootstrapView();
+    }
   }
 
   get hasTotp(): boolean {
@@ -201,6 +211,12 @@ export class TwoFactorAuthenticationComponent implements OnInit {
   }
 
   private bootstrapView(): void {
+    // Wait until we have an MFA status snapshot (cached or loaded).
+    if (!this.mfaStatus) {
+      this.view = 'loading';
+      return;
+    }
+
     const options = [
       this.hasTotp ? 'totp' : null,
       this.hasPasskey ? 'passkey' : null,
@@ -208,15 +224,14 @@ export class TwoFactorAuthenticationComponent implements OnInit {
     ].filter(Boolean) as ChallengeView[];
 
     if (options.length === 1) {
-      this.view = options[0] === 'legacy-delivery' ? 'legacy-delivery' : options[0];
+      this.view = options[0];
       return;
     }
     if (options.length > 1) {
       this.view = 'choose';
       return;
     }
-    // Fineract required 2FA but no methods yet — keep legacy delivery form ready.
-    this.view = 'legacy-delivery';
+    this.view = 'unavailable';
   }
 
   private createTwoFactorAuthenticationDeliveryMethodForm() {

--- a/src/app/profile/profile.component.html
+++ b/src/app/profile/profile.component.html
@@ -60,6 +60,8 @@
 
   </mat-card>
 
+  <mifosx-security-settings></mifosx-security-settings>
+
   <mat-card>
 
     <table class="mat-elevation-z1" mat-table [dataSource]="dataSource">

--- a/src/app/profile/profile.component.ts
+++ b/src/app/profile/profile.component.ts
@@ -8,6 +8,7 @@ import { Router, RouterLink } from '@angular/router';
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
 import { ChangePasswordDialogComponent } from 'app/shared/change-password-dialog/change-password-dialog.component';
 import { UserService } from 'app/self-service/users/user.service';
+import { SecuritySettingsComponent } from './security-settings/security-settings.component';
 import { LayoutDirective, LayoutAlignDirective, LayoutGapDirective, FlexDirective } from '@ngbracket/ngx-layout/flex';
 import { MatButton } from '@angular/material/button';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -21,7 +22,7 @@ import { MatCard } from '@angular/material/card';
     templateUrl: './profile.component.html',
     changeDetection: ChangeDetectionStrategy.Eager,
     styleUrls: ['./profile.component.scss'],
-    imports: [LayoutDirective, LayoutAlignDirective, LayoutGapDirective, MatButton, RouterLink, FaIconComponent, MatCard, FlexDirective, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow]
+    imports: [LayoutDirective, LayoutAlignDirective, LayoutGapDirective, MatButton, RouterLink, FaIconComponent, MatCard, FlexDirective, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, SecuritySettingsComponent]
 })
 export class ProfileComponent implements OnInit {
 

--- a/src/app/profile/security-settings/security-settings.component.html
+++ b/src/app/profile/security-settings/security-settings.component.html
@@ -1,0 +1,91 @@
+<mat-card class="security-settings" id="security-settings">
+
+  <h2>
+    <fa-icon icon="shield"></fa-icon>&nbsp;&nbsp;Security
+  </h2>
+  <p class="intro">
+    Protect your account with an authenticator app (TOTP) and optional passkeys.
+  </p>
+  <p class="demo-note" *ngIf="demoMode">
+    Demo MFA mode is on: secrets are stored in this browser only. Point
+    <code>environment.mfa</code> at a server and set <code>demoMode: false</code> for production.
+  </p>
+
+  <p class="feedback ok" *ngIf="message">{{ message }}</p>
+  <p class="feedback error" *ngIf="error">{{ error }}</p>
+
+  <mat-divider></mat-divider>
+
+  <section fxLayout="column" fxLayoutGap="0.75rem">
+    <h3>Authenticator app (TOTP)</h3>
+    <p *ngIf="status?.totpEnabled">Authenticator app is enabled for this account.</p>
+    <p *ngIf="!status?.totpEnabled && !setup">Add a TOTP authenticator as a second step after your password.</p>
+
+    <div *ngIf="setup" fxLayout="column" fxLayoutGap="0.5rem" class="totp-setup">
+      <img *ngIf="setup.qrDataUrl" [src]="setup.qrDataUrl" alt="TOTP QR code" class="totp-qr" width="220" height="220">
+      <p class="secret-line">
+        Manual key: <code id="totp-secret">{{ setup.secret }}</code>
+      </p>
+      <form [formGroup]="totpConfirmForm" (ngSubmit)="confirmTotpSetup()" fxLayout="row" fxLayoutGap="0.5rem" fxLayoutAlign="start center">
+        <mat-form-field>
+          <mat-label>Confirmation code</mat-label>
+          <input matInput formControlName="code" maxlength="6" inputmode="numeric" autocomplete="one-time-code" id="totp-confirm-code">
+          <mat-hint>Enter the current 6-digit code</mat-hint>
+          <mat-error *ngIf="totpConfirmForm.controls.code.invalid">Enter a 6-digit code</mat-error>
+        </mat-form-field>
+        <button mat-raised-button color="primary" type="submit" id="totp-confirm-button"
+          [disabled]="totpConfirmForm.invalid || loading">
+          Confirm
+          <mat-spinner diameter="18" *ngIf="loading"></mat-spinner>
+        </button>
+      </form>
+    </div>
+
+    <div fxLayout="row" fxLayoutGap="0.5rem">
+      <button mat-raised-button color="primary" type="button" id="totp-setup-button"
+        *ngIf="!status?.totpEnabled && !setup"
+        (click)="beginTotpSetup()" [disabled]="loading">
+        Set up authenticator
+      </button>
+      <button mat-stroked-button color="warn" type="button" id="totp-disable-button"
+        *ngIf="status?.totpEnabled"
+        (click)="disableTotp()" [disabled]="loading">
+        Disable authenticator
+      </button>
+    </div>
+  </section>
+
+  <mat-divider></mat-divider>
+
+  <section fxLayout="column" fxLayoutGap="0.75rem">
+    <h3>Passkeys</h3>
+    <p *ngIf="!passkeysSupported">This browser does not support passkeys (WebAuthn).</p>
+    <ng-container *ngIf="passkeysSupported">
+      <p>Register a device passkey for sign-in and MFA challenges.</p>
+
+      <ul class="passkey-list" *ngIf="status?.passkeys?.length">
+        <li *ngFor="let passkey of status?.passkeys" fxLayout="row" fxLayoutAlign="space-between center">
+          <div>
+            <strong>{{ passkey.name }}</strong>
+            <span class="meta"> · added {{ passkey.createdAt | date: 'mediumDate' }}</span>
+          </div>
+          <button mat-button color="warn" type="button" (click)="removePasskey(passkey)" [disabled]="loading">
+            <fa-icon icon="trash"></fa-icon>&nbsp;Remove
+          </button>
+        </li>
+      </ul>
+
+      <form [formGroup]="passkeyNameForm" (ngSubmit)="registerPasskey()" fxLayout="row" fxLayoutGap="0.5rem" fxLayoutAlign="start center">
+        <mat-form-field>
+          <mat-label>Passkey name</mat-label>
+          <input matInput formControlName="name" id="passkey-name">
+        </mat-form-field>
+        <button mat-raised-button color="primary" type="submit" id="passkey-register-button"
+          [disabled]="passkeyNameForm.invalid || loading">
+          <fa-icon icon="key"></fa-icon>&nbsp;Register passkey
+        </button>
+      </form>
+    </ng-container>
+  </section>
+
+</mat-card>

--- a/src/app/profile/security-settings/security-settings.component.scss
+++ b/src/app/profile/security-settings/security-settings.component.scss
@@ -1,0 +1,61 @@
+.security-settings {
+  h2 {
+    margin: 0 0 0.5rem;
+  }
+
+  .intro,
+  .demo-note {
+    margin: 0 0 1rem;
+    max-width: 40rem;
+  }
+
+  .demo-note {
+    opacity: 0.85;
+    font-size: 0.9rem;
+  }
+
+  section {
+    padding: 1rem 0;
+  }
+
+  .feedback {
+    margin: 0.5rem 0;
+
+    &.ok {
+      color: #2e7d32;
+    }
+
+    &.error {
+      color: #b71c1c;
+    }
+  }
+
+  .totp-qr {
+    border-radius: 0.25rem;
+  }
+
+  .secret-line {
+    word-break: break-all;
+  }
+
+  .passkey-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    li {
+      padding: 0.5rem 0;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    }
+
+    .meta {
+      opacity: 0.7;
+      font-size: 0.85rem;
+    }
+  }
+
+  mat-spinner {
+    display: inline-block;
+    margin-left: 0.5rem;
+  }
+}

--- a/src/app/profile/security-settings/security-settings.component.ts
+++ b/src/app/profile/security-settings/security-settings.component.ts
@@ -1,0 +1,169 @@
+/** Angular Imports */
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NgIf, NgFor, DatePipe } from '@angular/common';
+import { finalize } from 'rxjs/operators';
+
+import { MatCard } from '@angular/material/card';
+import { MatButton } from '@angular/material/button';
+import { MatFormField, MatLabel, MatError, MatHint } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { MatDivider } from '@angular/material/divider';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { LayoutDirective, FlexDirective, LayoutGapDirective } from '@ngbracket/ngx-layout/flex';
+
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { MfaService } from 'app/core/mfa/mfa.service';
+import { MfaPasskeyCredential, MfaStatus, TotpSetupResponse } from 'app/core/mfa/mfa.models';
+import { environment } from '../../../environments/environment';
+
+/**
+ * Profile security settings: TOTP enrollment and passkey management.
+ */
+@Component({
+  selector: 'mifosx-security-settings',
+  templateUrl: './security-settings.component.html',
+  styleUrls: ['./security-settings.component.scss'],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  imports: [
+    NgIf, NgFor, DatePipe, ReactiveFormsModule, MatCard, MatButton, MatFormField, MatLabel,
+    MatError, MatHint, MatInput, MatProgressSpinner, MatDivider, FaIconComponent,
+    LayoutDirective, FlexDirective, LayoutGapDirective
+  ]
+})
+export class SecuritySettingsComponent implements OnInit {
+
+  status: MfaStatus | null = null;
+  setup: TotpSetupResponse | null = null;
+  totpConfirmForm: FormGroup;
+  passkeyNameForm: FormGroup;
+  loading = false;
+  message = '';
+  error = '';
+  demoMode = environment.mfa?.demoMode;
+  passkeysSupported = false;
+  username = '';
+
+  constructor(
+    private formBuilder: FormBuilder,
+    private authenticationService: AuthenticationService,
+    private mfaService: MfaService
+  ) {
+    this.totpConfirmForm = this.formBuilder.group({
+      code: ['', [Validators.required, Validators.pattern(/^\d{6}$/)]]
+    });
+    this.passkeyNameForm = this.formBuilder.group({
+      name: ['This device', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    this.passkeysSupported = this.mfaService.webAuthnAvailable();
+    this.username = this.authenticationService.getCredentials()?.username ?? '';
+    this.refreshStatus();
+  }
+
+  refreshStatus(): void {
+    if (!this.username) {
+      return;
+    }
+    this.mfaService.getStatus(this.username).subscribe({
+      next: (status) => {
+        this.status = status;
+      },
+      error: (err) => {
+        this.error = err?.message || 'Unable to load MFA status.';
+      }
+    });
+  }
+
+  beginTotpSetup(): void {
+    this.clearFeedback();
+    this.loading = true;
+    this.mfaService.beginTotpSetup(this.username)
+      .pipe(finalize(() => { this.loading = false; }))
+      .subscribe({
+        next: (setup) => {
+          this.setup = setup;
+          this.message = 'Scan the QR code with your authenticator app, then enter a code to confirm.';
+        },
+        error: (err) => {
+          this.error = err?.message || 'Unable to start authenticator setup.';
+        }
+      });
+  }
+
+  confirmTotpSetup(): void {
+    this.clearFeedback();
+    this.loading = true;
+    this.mfaService.confirmTotpSetup(this.username, this.totpConfirmForm.value.code)
+      .pipe(finalize(() => { this.loading = false; }))
+      .subscribe({
+        next: () => {
+          this.setup = null;
+          this.totpConfirmForm.reset();
+          this.message = 'Authenticator app enabled.';
+          this.refreshStatus();
+        },
+        error: (err) => {
+          this.error = err?.message || 'Could not confirm authenticator code.';
+        }
+      });
+  }
+
+  disableTotp(): void {
+    this.clearFeedback();
+    this.loading = true;
+    this.mfaService.disableTotp(this.username)
+      .pipe(finalize(() => { this.loading = false; }))
+      .subscribe({
+        next: () => {
+          this.setup = null;
+          this.message = 'Authenticator app disabled.';
+          this.refreshStatus();
+        },
+        error: (err) => {
+          this.error = err?.message || 'Could not disable authenticator.';
+        }
+      });
+  }
+
+  registerPasskey(): void {
+    this.clearFeedback();
+    this.loading = true;
+    const credentials = this.authenticationService.getCredentials() ?? undefined;
+    this.mfaService.registerPasskey(this.username, this.passkeyNameForm.value.name, credentials ?? undefined)
+      .pipe(finalize(() => { this.loading = false; }))
+      .subscribe({
+        next: () => {
+          this.message = 'Passkey registered. You can use it on the login screen.';
+          this.refreshStatus();
+        },
+        error: (err) => {
+          this.error = err?.message || 'Passkey registration failed.';
+        }
+      });
+  }
+
+  removePasskey(passkey: MfaPasskeyCredential): void {
+    this.clearFeedback();
+    this.loading = true;
+    this.mfaService.removePasskey(this.username, passkey.id)
+      .pipe(finalize(() => { this.loading = false; }))
+      .subscribe({
+        next: () => {
+          this.message = `Removed passkey “${passkey.name}”.`;
+          this.refreshStatus();
+        },
+        error: (err) => {
+          this.error = err?.message || 'Could not remove passkey.';
+        }
+      });
+  }
+
+  private clearFeedback(): void {
+    this.message = '';
+    this.error = '';
+  }
+}

--- a/src/app/users/edit-user/edit-user.component.ts
+++ b/src/app/users/edit-user/edit-user.component.ts
@@ -19,7 +19,6 @@ import { MatButton } from '@angular/material/button';
  * Edit User Component.
  */
 @Component({
-  standalone: false,
     selector: 'mifosx-edit-user',
     templateUrl: './edit-user.component.html',
     changeDetection: ChangeDetectionStrategy.Eager,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -18,7 +18,17 @@ export const environment = {
   supportedLanguages: [
     'en-US',
     'fr-FR'
-  ]
+  ],
+  /**
+   * App-level MFA (TOTP + passkeys). Keep demoMode false in production and
+   * serve a backend that implements the /mfa HTTP contract.
+   */
+  mfa: {
+    demoMode: false,
+    rpId: '',
+    rpName: 'Mifos X',
+    apiPath: '/mfa'
+  }
 };
 
 // Server URL

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -23,7 +23,18 @@ export const environment = {
   supportedLanguages: [
     'en-US',
     'fr-FR'
-  ]
+  ],
+  /**
+   * App-level MFA (TOTP + passkeys). Fineract SMS/email OTP remains separate.
+   * demoMode stores secrets in IndexedDB for local/e2e use; set false and point
+   * apiPath at an MFA sidecar for production.
+   */
+  mfa: {
+    demoMode: true,
+    rpId: '',
+    rpName: 'Mifos X',
+    apiPath: '/mfa'
+  }
 };
 
 // Server URL


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds application-level multi-factor authentication with **TOTP authenticator apps** and **WebAuthn passkeys**, alongside the existing Fineract SMS/email OTP flow.

### What’s included
- **MFA core** (`src/app/core/mfa/`): models, IndexedDB demo vault, TOTP helpers (`otpauth`), WebAuthn helpers, `MfaService`
- **Auth integration**: after password success, challenge when TOTP/passkeys are enrolled; `loginWithPasskey()` for passwordless (demo session handoff)
- **Login UI**: method chooser on MFA challenge (TOTP / passkey / SMS-email); passkey button on login form
- **Profile → Security**: enroll/confirm/disable TOTP; register/remove passkeys
- **Config**: `environment.mfa` (`demoMode`, `rpId`, `rpName`, `apiPath`)
- **Docs**: `docs/MFA.md` with HTTP sidecar contract
- **Tests**: unit coverage for TOTP/WebAuthn utils; Playwright TOTP challenge e2e with vault seeding

### Notes
- Development uses `mfa.demoMode: true` (browser vault). Production sets `demoMode: false` and expects an MFA sidecar under `/mfa`.
- Fineract does not natively speak TOTP/WebAuthn; SMS/email OTP remains on `/twofactor`.

## Verification
- `npm run test:ci` — 617 tests passed
- `npm run e2e:ci` — 6/6 passed (login + MFA TOTP)

## Test plan
- [x] Unit tests
- [x] Playwright e2e (login without MFA + TOTP challenge)
- [ ] Manually: Profile → Security → set up TOTP → logout → login → enter authenticator code
- [ ] Manually (supporting browser): register passkey → MFA or passwordless login

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4a79-7a8c-7a4b-b957-a553ed0e739b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4a79-7a8c-7a4b-b957-a553ed0e739b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

